### PR TITLE
add `historicalDataCollection` option to the health data component

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -39,6 +39,7 @@ let package = Package(
             dependencies: [
                 .product(name: "ModelsR4", package: "FHIRModels"),
                 .product(name: "SpeziHealthKit", package: "SpeziHealthKit"),
+                .product(name: "SpeziHealthKitBulkExport", package: "SpeziHealthKit"),
                 .product(name: "SpeziFoundation", package: "SpeziFoundation"),
                 .product(name: "SpeziScheduler", package: "SpeziScheduler"),
                 .product(name: "DequeModule", package: "swift-collections")

--- a/Sources/SpeziStudyDefinition/Study Definition Components/HealthDataCollectionComponent.swift
+++ b/Sources/SpeziStudyDefinition/Study Definition Components/HealthDataCollectionComponent.swift
@@ -1,0 +1,35 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import SpeziHealthKit
+import SpeziHealthKitBulkExport
+
+
+extension StudyDefinition {
+    /// Study Component which initiates background Health data collection
+    public struct HealthDataCollectionComponent: Identifiable, StudyDefinitionElement {
+        /// Defines a ``StudyDefinition/HealthDataCollectionComponent``'s collection of historical Health data.
+        public enum HistoricalDataCollection: StudyDefinitionElement {
+            /// The component should not collect historical data, i.e. should limit its collection only to new data added to the Health Store.
+            case disabled
+            /// The component should, in addition to collecting new data added to the Health Store,
+            /// also collect historical data, starting at the specified start date.
+            case enabled(ExportSessionStartDate)
+        }
+        public var id: UUID
+        public var sampleTypes: SampleTypesCollection
+        public var historicalDataCollection: HistoricalDataCollection
+        
+        public init(id: UUID, sampleTypes: SampleTypesCollection, historicalDataCollection: HistoricalDataCollection) {
+            self.id = id
+            self.sampleTypes = sampleTypes
+            self.historicalDataCollection = historicalDataCollection
+        }
+    }
+}

--- a/Sources/SpeziStudyDefinition/Study Definition Components/InformationalComponent.swift
+++ b/Sources/SpeziStudyDefinition/Study Definition Components/InformationalComponent.swift
@@ -1,0 +1,27 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+
+
+extension StudyDefinition {
+    /// Study Component which prompts the participant to read an informational article
+    public struct InformationalComponent: Identifiable, StudyDefinitionElement {
+        public var id: UUID
+        public var title: String
+        public var headerImage: String
+        public var body: String
+        
+        public init(id: UUID, title: String, headerImage: String, body: String) {
+            self.id = id
+            self.title = title
+            self.headerImage = headerImage
+            self.body = body
+        }
+    }
+}

--- a/Sources/SpeziStudyDefinition/Study Definition Components/QuestionnaireComponent.swift
+++ b/Sources/SpeziStudyDefinition/Study Definition Components/QuestionnaireComponent.swift
@@ -1,0 +1,25 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2025 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+@preconcurrency import class ModelsR4.Questionnaire
+
+
+extension StudyDefinition {
+    /// Study Component which prompts the participant to answer a questionnaire
+    public struct QuestionnaireComponent: Identifiable, StudyDefinitionElement {
+        /// - parameter id: the id of this study component, **not** of the questionnaire
+        public let id: UUID
+        public let questionnaire: Questionnaire
+        
+        public init(id: UUID, questionnaire: Questionnaire) {
+            self.id = id
+            self.questionnaire = questionnaire
+        }
+    }
+}

--- a/Sources/SpeziStudyDefinition/StudyDefinition+Components.swift
+++ b/Sources/SpeziStudyDefinition/StudyDefinition+Components.swift
@@ -7,11 +7,7 @@
 //
 
 import Foundation
-import SpeziHealthKit
-@preconcurrency import class ModelsR4.Questionnaire
 
-
-// MARK: Definitions
 
 extension StudyDefinition {
     /// A Component within a ``StudyDefinition``
@@ -68,53 +64,6 @@ extension StudyDefinition {
             case .healthDataCollection:
                 .internal
             }
-        }
-    }
-}
-
-
-extension StudyDefinition {
-    /// Study Component which prompts the participant to read an informational article
-    public struct InformationalComponent: Identifiable, StudyDefinitionElement {
-        public var id: UUID
-        public var title: String
-        public var headerImage: String
-        public var body: String
-        
-        public init(id: UUID, title: String, headerImage: String, body: String) {
-            self.id = id
-            self.title = title
-            self.headerImage = headerImage
-            self.body = body
-        }
-    }
-}
-
-
-extension StudyDefinition {
-    /// Study Component which prompts the participant to answer a questionnaire
-    public struct QuestionnaireComponent: Identifiable, StudyDefinitionElement {
-        /// - parameter id: the id of this study component, **not** of the questionnaire
-        public let id: UUID
-        public let questionnaire: Questionnaire
-        
-        public init(id: UUID, questionnaire: Questionnaire) {
-            self.id = id
-            self.questionnaire = questionnaire
-        }
-    }
-}
-
-
-extension StudyDefinition {
-    /// Study Component which initiates background Health data collection
-    public struct HealthDataCollectionComponent: Identifiable, StudyDefinitionElement {
-        public var id: UUID
-        public var sampleTypes: SampleTypesCollection
-        
-        public init(id: UUID, sampleTypes: SampleTypesCollection) {
-            self.id = id
-            self.sampleTypes = sampleTypes
         }
     }
 }

--- a/Sources/SpeziStudyDefinition/StudyDefinition.swift
+++ b/Sources/SpeziStudyDefinition/StudyDefinition.swift
@@ -29,7 +29,7 @@ public typealias StudyDefinitionElement = Hashable & Codable & Sendable
 /// Currently, there are 3 kinds of components:
 /// 1. ``InformationalComponent``s, which display static informational text, e.g. an article;
 /// 2. ``QuestionnaireComponent``s, which prompt the participant to answer a questionnaire;
-/// 3. ``HealthDataCollectionComponent``s, which configure and enable background collection of HealthKit data.
+/// 3. ``HealthDataCollectionComponent``s, which configure and enable background collection of HealthKit data, including optional collection of historical data.
 ///
 /// The ``StudyDefinition`` type is explicitly designed to be used with Swift's `Codable` infrastructure: it conforms to both the `Encodable` protocol, as well as `DecodableWithConfiguration`.
 /// This allows apps to easily locally persist study definitions across app launches, and to transfer them between devices, e.g., an a study app could host its study definition on a server and then
@@ -76,7 +76,7 @@ public typealias StudyDefinitionElement = Hashable & Codable & Sendable
 /// - ``validate()``
 public struct StudyDefinition: Identifiable, Hashable, Sendable, Encodable, DecodableWithConfiguration {
     /// The ``StudyDefinition`` type's current schema version.
-    public static let schemaVersion = Version(0, 4, 0)
+    public static let schemaVersion = Version(0, 5, 0)
     
     /// The revision of the study.
     ///

--- a/Tests/SpeziStudyTests/StudyDefinitionTests.swift
+++ b/Tests/SpeziStudyTests/StudyDefinitionTests.swift
@@ -9,10 +9,13 @@
 import Foundation
 import class ModelsR4.Questionnaire
 import SpeziFoundation
+import SpeziHealthKit
+import SpeziHealthKitBulkExport
 @testable import SpeziStudyDefinition
 import Testing
 
 
+@Suite
 struct StudyDefinitionTests {
     @Test
     func studyEncodingAndDecoding() throws {
@@ -63,6 +66,7 @@ extension StudyDefinitionTests {
             let article1ComponentId = UUID(uuidString: "F924B17E-F45C-40D8-8B8A-C694C6D4956D")!
             let article2ComponentId = UUID(uuidString: "6BE663DB-912F-4F4E-BD62-D743A9FB8941")!
             let questionnaireComponentId = UUID(uuidString: "7E3CD36F-26CD-418B-9CAD-CFB268070162")!
+            let healthDataCollectionComponentId = UUID(uuidString: "A52CBB75-6F9D-4B59-BA86-01532EFE41D2")!
             // swiftlint:enable force_unwrapping
             return StudyDefinition(
                 studyRevision: 0,
@@ -91,6 +95,11 @@ extension StudyDefinitionTests {
                     .questionnaire(.init(
                         id: questionnaireComponentId,
                         questionnaire: try .named("SocialSupportQuestionnaire")
+                    )),
+                    .healthDataCollection(.init(
+                        id: healthDataCollectionComponentId,
+                        sampleTypes: [SampleType.heartRate, SampleType.stepCount, SampleType.sleepAnalysis],
+                        historicalDataCollection: .enabled(.last(DateComponents(year: 7, month: 6)))
                     ))
                 ],
                 componentSchedules: [

--- a/Tests/UITests/TestApp/MockStudy.swift
+++ b/Tests/UITests/TestApp/MockStudy.swift
@@ -67,7 +67,8 @@ func mockStudy(revision: MockStudyRevision) -> StudyDefinition { // swiftlint:di
                     quantity: [.stepCount, .heartRate, .activeEnergyBurned],
                     correlation: [.bloodPressure],
                     category: [.sleepAnalysis]
-                )
+                ),
+                historicalDataCollection: .disabled
             ))
             switch revision {
             case .v1:


### PR DESCRIPTION
# add `historicalDataCollection` option to the health data component

## :recycle: Current situation & Problem
This PR extends the `HealthDataCollection` study component to add a `historicalDataCollection` property, which can be used to specify whether the study's health data collection should be limited to just collecting new samples (the current behaviour), or whether it should also include a bulk export of historical samples.

Note that this PR only adds the field to the StudyDefinition; it does not add any historical data exporting to the StudyManager. This is intentional, since an app would need to be able to control how and when this happens, and (in contrast to the rolling new-sample collection) there isn't an elegant way of having this be handled through the StudyManager. (Not adding this right now would of course still allow us to add this at some point in the future.)

additionally, this PR also restructures the different study components to put each component into its own file.


## :gear: Release Notes
- added `historicalDataCollection` property to the `StudyDefinition.HealthDataCollection` study component.


## :books: Documentation
the new code is documented.

## :white_check_mark: Testing
both the unit tests as well as the UI tests have been updated to test the new code.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
