### PR TITLE
relax FHIRModels version requirement

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -25,13 +25,13 @@ let package = Package(
         .library(name: "SpeziStudyDefinition", targets: ["SpeziStudyDefinition"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/FHIRModels.git", .upToNextMinor(from: "0.5.0")),
-        .package(url: "https://github.com/StanfordSpezi/Spezi.git", .upToNextMajor(from: "1.8.1")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", .upToNextMajor(from: "2.1.4")),
-        .package(url: "https://github.com/StanfordSpezi/SpeziHealthKit.git", .upToNextMajor(from: "1.1.0")),
+        .package(url: "https://github.com/apple/FHIRModels.git", from: "0.5.0"),
+        .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.8.1"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.1.4"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziHealthKit.git", from: "1.1.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziScheduler.git", from: "1.2.7"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", .upToNextMajor(from: "2.1.0")),
-        .package(url: "https://github.com/apple/swift-collections.git", .upToNextMajor(from: "1.1.4"))
+        .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "2.1.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.4")
     ] + swiftLintPackage(),
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -25,7 +25,7 @@ let package = Package(
         .library(name: "SpeziStudyDefinition", targets: ["SpeziStudyDefinition"])
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/FHIRModels.git", from: "0.5.0"),
+        .package(url: "https://github.com/apple/FHIRModels.git", from: "0.7.0"),
         .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.8.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.1.4"),
         .package(url: "https://github.com/StanfordSpezi/SpeziHealthKit.git", from: "1.1.0"),


### PR DESCRIPTION
# relax FHIRModels version requirement

## :recycle: Current situation & Problem
relaxes the FHIRModels version requirement from upToNextMinor to upToNextMajor; replaces all with the more elegant `from:` overload.


## :gear: Release Notes
n/a


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
