### PR TITLE
allow defining how missed task occurrences should be handled

### DIFF
--- a/Sources/SpeziStudyDefinition/StudyDefinition+Schedule.swift
+++ b/Sources/SpeziStudyDefinition/StudyDefinition+Schedule.swift
@@ -84,6 +84,25 @@ extension StudyDefinition {
             }
         }
         
+        /// What should happen with missed occurrences of events scheduled based on ``ScheduleDefinition-swift.enum``s,
+        /// i.e. Tasks the user was prompted to complete but didn't complete and which are now in the past.
+        public enum MissedOccurrenceRule: StudyDefinitionElement {
+            /// The missed occurrence of the scheduled task should be discarded, and it should not be possible for the user to complete the event retroactively.
+            case discard
+            /// The user should be given the option to retroactively complete the event, even if it occurred on a date that has already passed.
+            case allowCompletion(AllowCompletionDeadline)
+            
+            /// Until when a user should be allowed to complete an already-passed occurrence of a Task.
+            public enum AllowCompletionDeadline: StudyDefinitionElement {
+                /// Retroactive completion should always be possible, regardless of how long ago the missed occurrence was.
+                case forever
+                /// Retroactive completion should be possible, until the next regular occurrence of the Task.
+                ///
+                /// For example, if you have a weekly schedule, and the user misses completion, they'd be given the option to retroactively complete the task for the next 6 days.
+                case untilNextOccurrence
+            }
+        }
+        
         /// This schedule's unique, stable identifier.
         public var id: UUID
         /// The identifier of the component this schedule is referencing
@@ -94,6 +113,8 @@ extension StudyDefinition {
         public var completionPolicy: SpeziScheduler.AllowedCompletionPolicy
         /// Whether notifications should be sent for occurrences of this schedule.
         public var notifications: NotificationsConfig
+        /// How missed occurrences of the scheduled task should be handled.
+        public var missedOccurrenceRule: MissedOccurrenceRule
         
         /// Creates a new `ComponentSchedule`.
         public init(
@@ -101,13 +122,15 @@ extension StudyDefinition {
             componentId: StudyDefinition.Component.ID,
             scheduleDefinition: ScheduleDefinition,
             completionPolicy: SpeziScheduler.AllowedCompletionPolicy,
-            notifications: NotificationsConfig
+            notifications: NotificationsConfig,
+            missedOccurrenceRule: MissedOccurrenceRule = .discard
         ) {
             self.id = id
             self.componentId = componentId
             self.scheduleDefinition = scheduleDefinition
             self.completionPolicy = completionPolicy
             self.notifications = notifications
+            self.missedOccurrenceRule = missedOccurrenceRule
         }
     }
 }

--- a/Sources/SpeziStudyDefinition/StudyDefinition.swift
+++ b/Sources/SpeziStudyDefinition/StudyDefinition.swift
@@ -77,7 +77,7 @@ public typealias StudyDefinitionElement = Hashable & Codable & Sendable
 /// - ``validate()``
 public struct StudyDefinition: Identifiable, Hashable, Sendable, Encodable, DecodableWithConfiguration {
     /// The ``StudyDefinition`` type's current schema version.
-    public static let schemaVersion = Version(0, 8, 0)
+    public static let schemaVersion = Version(0, 9, 0)
     
     /// The revision of the study.
     ///


### PR DESCRIPTION
# allow defining how missed task occurrences should be handled

## :recycle: Current situation & Problem
This PR adds a field to the StudyDefinition that allows defining, or a per-schedule basis, how missed occurrences of the task (ie, study component) scheduled by the schedule should be handled.

Note that the PR *does not* add any actual handling code to the StudyManager.
It only adds the ability to define the handling rule; for now an app using SpeziStudy would be responsible for taking this into account when building up its UI.

## :gear: Release Notes
- added `MissedOccurrenceRule` to Study Definition


## :books: Documentation
the new types and values are documented.


## :white_check_mark: Testing
there are no dedicated new tests, bc the PR only adds definitions but no logic; the existing tests should cover this.


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
