### PR TITLE
monthly schedules; improve relative scheduling

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -31,7 +31,7 @@ let package = Package(
         .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.8.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.2.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziHealthKit.git", from: "1.1.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziScheduler.git", from: "1.2.10"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziScheduler.git", from: "1.2.11"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "2.1.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.1.4"),
         .package(url: "https://github.com/apple/swift-algorithms", from: "1.2.1")

--- a/Sources/SpeziStudy/Study Manager/StudyManager+Other.swift
+++ b/Sources/SpeziStudy/Study Manager/StudyManager+Other.swift
@@ -127,7 +127,7 @@ extension Calendar {
             .flatMap(\.self)
             .dropFirst(self.firstWeekday - 1)
             .dropFirst(rawValue + self.weekdaySymbols.count - self.firstWeekday)
-            // SAFETY: we operate on what is essentially a neverending sequence of weekdays; there will always be an element
+            // SAFETY: we operate on what is effectively a neverending sequence; there will always be an element
             .first! // swiftlint:disable:this force_unwrapping
     }
 }

--- a/Sources/SpeziStudy/Study Manager/StudyManager.swift
+++ b/Sources/SpeziStudy/Study Manager/StudyManager.swift
@@ -274,7 +274,11 @@ extension StudyManager {
                     }
                     taskSchedule = .once(at: date, duration: .tillEndOfDay)
                 case .repeated:
-                    taskSchedule = .fromRepeated(schedule.scheduleDefinition, participationStartDate: enrollment.enrollmentDate)
+                    taskSchedule = .fromRepeated(
+                        schedule.scheduleDefinition,
+                        in: preferredLocale.calendar,
+                        participationStartDate: enrollment.enrollmentDate
+                    )
                 }
                 do {
                     let task = try createOrUpdateTask(

--- a/Sources/SpeziStudyDefinition/StudyDefinition+Schedule.swift
+++ b/Sources/SpeziStudyDefinition/StudyDefinition+Schedule.swift
@@ -64,7 +64,13 @@ extension StudyDefinition {
                 /// A repetition pattern that will take effect daily, at the specified `hour` and `minute`.
                 case daily(interval: Int = 1, hour: Int, minute: Int = 0)
                 /// A repetition pattern that will take effect weekly, at the specified `weekday`, `hour`, and `minute`.
-                case weekly(interval: Int = 1, weekday: Locale.Weekday, hour: Int, minute: Int = 0)
+                /// - parameter weekday: the day of the week at which the schedule should repeat.
+                ///     specifying `nil` causes the schedule to repeat weekly relative to the study enrollment date.
+                case weekly(interval: Int = 1, weekday: Locale.Weekday?, hour: Int, minute: Int = 0)
+                /// A repetition pattern that will take effect monthly, at the specified `day`, `hour`, and `minute`.
+                /// - parameter day: the day of the month at which the schedule should repeat.
+                ///     specifying `nil` causes the schedule to repeat monthly relative to the study enrollment date.
+                case monthly(interval: Int = 1, day: Int?, hour: Int, minute: Int = 0)
             }
         }
         
@@ -135,7 +141,17 @@ extension StudyDefinition.ComponentSchedule.ScheduleDefinition: CustomStringConv
             case 1: "weekly"
             default: "every \(Self.ordinalsFormatter.string(from: .init(value: interval)) ?? "\(interval)th") week"
             }
-            return "\(intervalDesc) @ \(weekday.rawValue) \(String(format: "%.2d", hour)):\(String(format: "%.2d", minute))\(Self.offsetDesc(offset))"
+            let timeDesc = "\(String(format: "%.2d", hour)):\(String(format: "%.2d", minute))\(Self.offsetDesc(offset))"
+            return "\(intervalDesc) @ \(weekday?.rawValue ?? "(study enrollment weekday)") \(timeDesc)"
+        case let .repeated(.monthly(interval, day, hour, minute), offset):
+            let intervalDesc = switch interval {
+            case ...0: ""
+            case 1: "monthly"
+            default: "every \(Self.ordinalsFormatter.string(from: .init(value: interval)) ?? "\(interval)th") month"
+            }
+            let timeDesc = "\(String(format: "%.2d", hour)):\(String(format: "%.2d", minute))\(Self.offsetDesc(offset))"
+            let dayDesc = day.map { "\(Self.ordinalsFormatter.string(from: .init(value: $0)) ?? "\($0)th") day" } ?? "(study enrollment day)"
+            return "\(intervalDesc) @ \(dayDesc) \(timeDesc)"
         case let .after(studyLifecycleEvent, offset):
             return "after \(studyLifecycleEvent)\(Self.offsetDesc(offset))"
         case .once(let dateComponents):

--- a/Sources/SpeziStudyDefinition/StudyDefinition.swift
+++ b/Sources/SpeziStudyDefinition/StudyDefinition.swift
@@ -77,7 +77,7 @@ public typealias StudyDefinitionElement = Hashable & Codable & Sendable
 /// - ``validate()``
 public struct StudyDefinition: Identifiable, Hashable, Sendable, Encodable, DecodableWithConfiguration {
     /// The ``StudyDefinition`` type's current schema version.
-    public static let schemaVersion = Version(0, 8, 0)
+    public static let schemaVersion = Version(0, 9, 0)
     
     /// The revision of the study.
     ///


### PR DESCRIPTION
# monthly schedules; improve enrollment-relative scheduling

## :recycle: Current situation & Problem
This PR:
- brings SpeziScheduler's new monthly schedule recurrence to SpeziStudy
- improves the scheduling of relative tasks:
    - for weekly schedules, the `weekday` component can now be set to `nil`, in which case the study enrollment's weekday is used instead
    - this allows defining repeating schedules relative to the enrollment, in a way that is natural wrt the recurrence rule: e.g., you can define a component as being scheduled first on the day the user enrolls into the study, and then repeating every week thereafter.
    - the monthly schedule's `day` component works the same way.


## :gear: Release Notes
- add support for monthly schedules
- allow starting schedules relative to the enrollment date (rather than eg a fixed weekday for weekly schedules)


## :books: Documentation
yes


## :white_check_mark: Testing
no(t yet)


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
