### PR TITLE
locale fixes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -28,7 +28,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/FHIRModels.git", from: "0.8.0"),
         .package(url: "https://github.com/StanfordSpezi/Spezi.git", from: "1.8.1"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.7.2"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.7.4"),
         .package(url: "https://github.com/StanfordSpezi/SpeziHealthKit.git", from: "1.3.2"),
         .package(url: "https://github.com/StanfordSpezi/SpeziScheduler.git", from: "1.2.14"),
         .package(url: "https://github.com/StanfordSpezi/SpeziStorage.git", from: "2.1.0"),

--- a/Sources/SpeziStudyDefinition/StudyBundle/StudyBundle+FileReference.swift
+++ b/Sources/SpeziStudyDefinition/StudyBundle/StudyBundle+FileReference.swift
@@ -146,19 +146,22 @@ extension StudyBundle {
     public func resolve(
         _ fileRef: FileReference,
         in locale: Locale,
-        using localeMatchingBehaviour: LocaleMatchingBehaviour = .default
+        using localeMatchingBehaviour: LocaleMatchingBehaviour = .default,
+        fallback fallbackLocale: LocalizationKey? = .enUS
     ) -> URL? {
         resolve(
             fileRef: fileRef,
             locale: locale,
-            localeMatchingBehaviour: localeMatchingBehaviour
+            localeMatchingBehaviour: localeMatchingBehaviour,
+            fallback: fallbackLocale
         )?.url
     }
     
     func resolve(
         fileRef: FileReference,
         locale: Locale,
-        localeMatchingBehaviour: LocaleMatchingBehaviour
+        localeMatchingBehaviour: LocaleMatchingBehaviour,
+        fallback fallbackLocale: LocalizationKey?
     ) -> (url: URL, localizedFileRef: LocalizedFileReference)? {
         let dirUrl = Self.folderUrl(for: fileRef.category, relativeTo: bundleUrl)
         guard let candidateUrls = try? FileManager.default.contents(of: dirUrl) else {
@@ -168,7 +171,7 @@ extension StudyBundle {
             LocalizedFileResource("\(fileRef.filename).\(fileRef.fileExtension)", locale: locale),
             from: candidateUrls,
             using: localeMatchingBehaviour,
-            fallback: .enUS
+            fallback: fallbackLocale
         )
         .map { ($0.url, .init(fileRef: fileRef, localization: $0.localization)) }
     }

--- a/Sources/SpeziStudyDefinition/StudyBundle/StudyBundle.swift
+++ b/Sources/SpeziStudyDefinition/StudyBundle/StudyBundle.swift
@@ -100,9 +100,10 @@ public struct StudyBundle: Identifiable, Sendable {
     public func questionnaire(
         for fileRef: FileReference,
         in locale: Locale,
-        using localeMatchingBehaviour: LocaleMatchingBehaviour = .default
+        using localeMatchingBehaviour: LocaleMatchingBehaviour = .default,
+        fallback fallbackLocale: LocalizationKey? = .enUS
     ) -> Questionnaire? {
-        _decodeResource(for: fileRef, locale: locale, using: localeMatchingBehaviour) {
+        _decodeResource(for: fileRef, locale: locale, using: localeMatchingBehaviour, fallback: fallbackLocale) {
             try JSONDecoder().decode(Questionnaire.self, from: $0)
         }
     }
@@ -111,12 +112,14 @@ public struct StudyBundle: Identifiable, Sendable {
     public func questionnaire(
         named questionnaireName: String,
         in locale: Locale,
-        using localeMatchingBehaviour: LocaleMatchingBehaviour = .default
+        using localeMatchingBehaviour: LocaleMatchingBehaviour = .default,
+        fallback fallbackLocale: LocalizationKey? = .enUS
     ) -> Questionnaire? {
         questionnaire(
             for: .init(category: .questionnaire, filename: questionnaireName, fileExtension: "json"),
             in: locale,
-            using: localeMatchingBehaviour
+            using: localeMatchingBehaviour,
+            fallback: fallbackLocale
         )
     }
     
@@ -124,9 +127,10 @@ public struct StudyBundle: Identifiable, Sendable {
     public func consentText(
         for fileRef: FileReference,
         in locale: Locale,
-        using localeMatchingBehaviour: LocaleMatchingBehaviour = .default
+        using localeMatchingBehaviour: LocaleMatchingBehaviour = .default,
+        fallbackLocale: LocalizationKey?
     ) -> String? {
-        _decodeResource(for: fileRef, locale: locale, using: localeMatchingBehaviour) {
+        _decodeResource(for: fileRef, locale: locale, using: localeMatchingBehaviour, fallback: fallbackLocale) {
             String(data: $0, encoding: .utf8)
         }
     }
@@ -136,9 +140,15 @@ public struct StudyBundle: Identifiable, Sendable {
         for fileRef: FileReference,
         locale: Locale,
         using localeMatchingBehaviour: LocaleMatchingBehaviour,
+        fallback fallbackLocale: LocalizationKey?,
         decode: (Data) throws -> T?
     ) -> T? {
-        guard let url = resolve(fileRef: fileRef, locale: locale, localeMatchingBehaviour: localeMatchingBehaviour)?.url else {
+        guard let url = resolve(
+            fileRef: fileRef,
+            locale: locale,
+            localeMatchingBehaviour: localeMatchingBehaviour,
+            fallback: fallbackLocale
+        )?.url else {
             return nil
         }
         guard let data = try? Data(contentsOf: url) else {

--- a/Sources/SpeziStudyDefinition/StudyBundle/StudyBundle.swift
+++ b/Sources/SpeziStudyDefinition/StudyBundle/StudyBundle.swift
@@ -127,7 +127,7 @@ public struct StudyBundle: Identifiable, Sendable {
     public func consentText(
         for fileRef: FileReference,
         in locale: Locale,
-        using localeMatchingBehaviour: LocaleMatchingBehaviour = .default,
+        using localeMatchingBehaviour: LocaleMatchingBehaviour = .default, // swiftlint:disable:this function_default_parameter_at_end
         fallbackLocale: LocalizationKey?
     ) -> String? {
         _decodeResource(for: fileRef, locale: locale, using: localeMatchingBehaviour, fallback: fallbackLocale) {

--- a/Sources/SpeziStudyDefinition/StudyDefinition.swift
+++ b/Sources/SpeziStudyDefinition/StudyDefinition.swift
@@ -201,9 +201,10 @@ extension StudyBundle {
     public func documentMetadata(
         for component: StudyDefinition.InformationalComponent,
         in locale: Locale,
-        using localeMatchingBehaviour: LocaleMatchingBehaviour = .default
+        using localeMatchingBehaviour: LocaleMatchingBehaviour = .default,
+        fallback fallbackLocale: LocalizationKey? = .enUS
     ) -> MarkdownDocument.Metadata? {
-        guard let url = self.resolve(component.fileRef, in: locale, using: localeMatchingBehaviour),
+        guard let url = self.resolve(component.fileRef, in: locale, using: localeMatchingBehaviour, fallback: fallbackLocale),
               let text = (try? Data(contentsOf: url)).flatMap({ String(data: $0, encoding: .utf8) }) else {
             return nil
         }

--- a/Tests/SpeziStudyTests/StudyBundleTests.swift
+++ b/Tests/SpeziStudyTests/StudyBundleTests.swift
@@ -96,7 +96,8 @@ struct StudyBundleTests {
         let studyBundle = try Self.testStudyBundle
         #expect(studyBundle.consentText(
             for: .init(category: .consent, filename: "Consent", fileExtension: "md"),
-            in: Self.locale
+            in: Self.locale,
+            fallbackLocale: nil
         ) == "---\ntitle: Study Consent\n---\n\n# Consent")
     }
     


### PR DESCRIPTION
# locale fixes


## :gear: Release Notes
- allows customizing the fallback locale when resolving file refs (used to unconditionally default to `en-US`)


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a (we have some tests around this in SpeziFoundation)


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional fallback locale option for resource, questionnaire and consent lookups and for informational document metadata; callers can specify an alternate language when the requested locale is unavailable (defaults to English US).
* **Tests**
  * Updated tests to exercise the new fallback parameter in resource/consent lookups.
* **Chores**
  * Bumped a package dependency version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->