### PR TITLE
limit FHIRModels dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,6 @@ func products() -> [Product] {
 
 func dependencies() -> [PackageDescription.Package.Dependency] {
     var dependencies: [PackageDescription.Package.Dependency] = [
-        .package(url: "https://github.com/apple/FHIRModels.git", from: "0.8.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.7.4"),
         .package(url: "https://github.com/StanfordSpezi/SpeziHealthKit.git", from: "1.4.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziScheduler.git", from: "1.2.19"),
@@ -61,7 +60,6 @@ func targets() -> [Target] { // swiftlint:disable:this function_body_length
     var targets: [Target] = []
 
     let speziStudyDefinitionDependencies: [Target.Dependency] = [
-        .product(name: "ModelsR4", package: "FHIRModels"),
         .product(name: "SpeziHealthKit", package: "SpeziHealthKit"),
         .product(name: "SpeziHealthKitBulkExport", package: "SpeziHealthKit"),
         .product(name: "SpeziFoundation", package: "SpeziFoundation"),
@@ -82,9 +80,8 @@ func targets() -> [Target] { // swiftlint:disable:this function_body_length
     targets.append(.target(
         name: "SpeziStudy",
         dependencies: [
-            .target(name: "SpeziStudyDefinition"),
+            "SpeziStudyDefinition",
             .product(name: "Spezi", package: "Spezi"),
-            .product(name: "ModelsR4", package: "FHIRModels"),
             .product(name: "SpeziHealthKit", package: "SpeziHealthKit"),
             .product(name: "SpeziLocalStorage", package: "SpeziStorage"),
             .product(name: "SpeziScheduler", package: "SpeziScheduler"),
@@ -97,12 +94,11 @@ func targets() -> [Target] { // swiftlint:disable:this function_body_length
     #endif
 
     var speziStudyTestsDependencies: [Target.Dependency] = [
-        .target(name: "SpeziStudyDefinition"),
-        .product(name: "ModelsR4", package: "FHIRModels")
+        "SpeziStudyDefinition"
     ]
     #if canImport(Darwin)
     speziStudyTestsDependencies.append(contentsOf: [
-        .target(name: "SpeziStudy"),
+        "SpeziStudy",
         .product(name: "SpeziTesting", package: "Spezi")
     ])
     #endif

--- a/Package.swift
+++ b/Package.swift
@@ -40,6 +40,7 @@ func products() -> [Product] {
 
 func dependencies() -> [PackageDescription.Package.Dependency] {
     var dependencies: [PackageDescription.Package.Dependency] = [
+        .package(url: "https://github.com/apple/FHIRModels.git", "0.8.0"..<"0.9.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation.git", from: "2.7.4"),
         .package(url: "https://github.com/StanfordSpezi/SpeziHealthKit.git", from: "1.4.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziScheduler.git", from: "1.2.19"),
@@ -60,6 +61,7 @@ func targets() -> [Target] { // swiftlint:disable:this function_body_length
     var targets: [Target] = []
 
     let speziStudyDefinitionDependencies: [Target.Dependency] = [
+        .product(name: "ModelsR4", package: "FHIRModels"),
         .product(name: "SpeziHealthKit", package: "SpeziHealthKit"),
         .product(name: "SpeziHealthKitBulkExport", package: "SpeziHealthKit"),
         .product(name: "SpeziFoundation", package: "SpeziFoundation"),
@@ -80,8 +82,9 @@ func targets() -> [Target] { // swiftlint:disable:this function_body_length
     targets.append(.target(
         name: "SpeziStudy",
         dependencies: [
-            "SpeziStudyDefinition",
+            .target(name: "SpeziStudyDefinition"),
             .product(name: "Spezi", package: "Spezi"),
+            .product(name: "ModelsR4", package: "FHIRModels"),
             .product(name: "SpeziHealthKit", package: "SpeziHealthKit"),
             .product(name: "SpeziLocalStorage", package: "SpeziStorage"),
             .product(name: "SpeziScheduler", package: "SpeziScheduler"),
@@ -94,11 +97,12 @@ func targets() -> [Target] { // swiftlint:disable:this function_body_length
     #endif
 
     var speziStudyTestsDependencies: [Target.Dependency] = [
-        "SpeziStudyDefinition"
+        .target(name: "SpeziStudyDefinition"),
+        .product(name: "ModelsR4", package: "FHIRModels")
     ]
     #if canImport(Darwin)
     speziStudyTestsDependencies.append(contentsOf: [
-        "SpeziStudy",
+        .target(name: "SpeziStudy"),
         .product(name: "SpeziTesting", package: "Spezi")
     ])
     #endif


### PR DESCRIPTION
# limit FHIRModels dependency

## :recycle: Current situation & Problem
FHIRModels tagged a breaking 0.9.0 release, which our codebase will need to be updated to support.
in the meantime, we tighten our version requirement to keep our code compiling until we can update all our packages to the new types.


## :gear: Release Notes
- FHIRModels dependency now is explicitly limited to `0.8.0..<0.9.0`


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


### Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordBDHG/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordBDHG/.github/blob/main/CONTRIBUTING.md).
